### PR TITLE
Fix Python shell expansion - resolves #90

### DIFF
--- a/src/rez/bind/python.py
+++ b/src/rez/bind/python.py
@@ -30,7 +30,7 @@ call {python} %*
 
 sh = """\
 #!/usr/bin/env bash
-{python} $*
+{python} "$@"
 """
 
 


### PR DESCRIPTION
This should fix the shell expension when using `rez bind python` and then for example `rez env python -- python -c "assert True"`. The problem was reported in [this issue](https://github.com/mottosso/bleeding-rez/issues/90).
Tested on Fedora 30 en CentOS 7 (docker) with Python 2 and 3.