### PR TITLE
Add support for --rcfile argument on powershell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## 2.40.4 (2019-12-11)
+
+**Notes**
+
+Enable supporting the --rcfile argument for powershell.
+The file specified after this flag is injected right before the info You are now in a rez-configured environment.' in the target_file
+
+
 ## 2.40.3 (2019-08-15)
 [Source](https://github.com/nerdvegas/rez/tree/2.40.3) | [Diff](https://github.com/nerdvegas/rez/compare/2.40.2...2.40.3)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,19 @@
 
 **Notes**
 
-Enable supporting the --rcfile argument for powershell.
-The file specified after this flag is injected right before the info You are now in a rez-configured environment.' in the target_file
+- Enable support for the --rcfile argument for powershell.
+	The file specified after this flag is injected right before the info "You are now in a rez-configured environment." in the target_file
+- Enable support for the --stdin argument for powershell.
 
+Testing this new feature has been activated by doing the following changes:
+- the test test_shells.test_rcfile now adds an extension to the rcfile created
+
+- the function rez.util.create_executable_script has been changed to work on linux and windows
+
+- the binding rez.bind.hello_world.py has been changed to work on linux and windows
+
+- the decorator rez.tests.utils.shell_dependent, has been edited to stop skipping everything once a shell has been excluded
+	(replaced self.skipTest by continue)
 
 ## 2.40.3 (2019-08-15)
 [Source](https://github.com/nerdvegas/rez/tree/2.40.3) | [Diff](https://github.com/nerdvegas/rez/compare/2.40.2...2.40.3)

--- a/src/rez/tests/test_shells.py
+++ b/src/rez/tests/test_shells.py
@@ -133,7 +133,8 @@ class TestShells(TestBase, TempdirMixin):
         rcfile, _, _, command = sh.startup_capabilities(rcfile=True, command=True)
 
         if rcfile and command:
-            f, path = tempfile.mkstemp()
+            # Force extension (mainly needed for windows)
+            f, path = tempfile.mkstemp(prefix="rcfile_", suffix=".{}".format(sh.file_extension()))
             os.write(f, "hello_world\n")
             os.close(f)
 

--- a/src/rez/tests/util.py
+++ b/src/rez/tests/util.py
@@ -189,7 +189,8 @@ def shell_dependent(exclude=None):
 
             for shell in shells:
                 if exclude and shell in exclude:
-                    self.skipTest("This test does not run on %s shell." % shell)
+                    print("This test does not run on %s shell." % shell)
+                    continue
                 print("\ntesting in shell: %s..." % shell)
                 config.override("default_shell", shell)
                 func(self, *args, **kwargs)

--- a/src/rez/util.py
+++ b/src/rez/util.py
@@ -45,10 +45,16 @@ def create_executable_script(filepath, body, program=None):
 
     if not body.endswith('\n'):
         body += '\n'
+    
+    if os.name == "nt":
+        if program == "cmd" and not filepath.endswith(".bat"):
+            filepath += ".bat"
+        if program == "powershell" and not filepath.endswith(".ps1"):
+            filepath += ".ps1"
 
     with open(filepath, 'w') as f:
-        # TODO: make cross platform
-        f.write("#!/usr/bin/env %s\n" % program)
+        if os.name == "posix":
+            f.write("#!/usr/bin/env %s\n" % program)
         f.write(body)
 
     # TODO: Although Windows supports os.chmod you can only set the readonly

--- a/src/rez/utils/_version.py
+++ b/src/rez/utils/_version.py
@@ -1,7 +1,7 @@
 
 
 # Update this value to version up Rez. Do not place anything else in this file.
-_rez_version = "2.40.3"
+_rez_version = "2.40.4"
 
 
 # Copyright 2013-2016 Allan Johns.

--- a/src/rezplugins/shell/powershell.py
+++ b/src/rezplugins/shell/powershell.py
@@ -36,10 +36,8 @@ class PowerShell(CMD):
     @classmethod
     def startup_capabilities(cls, rcfile=False, norc=False, stdin=False,
                              command=False):
-        cls._unsupported_option('rcfile', rcfile)
         cls._unsupported_option('norc', norc)
         cls._unsupported_option('stdin', stdin)
-        rcfile = False
         norc = False
         stdin = False
         return (rcfile, norc, stdin, command)
@@ -48,13 +46,21 @@ class PowerShell(CMD):
     def get_startup_sequence(cls, rcfile, norc, stdin, command):
         rcfile, norc, stdin, command = \
             cls.startup_capabilities(rcfile, norc, stdin, command)
+            
+        files = []
+        do_rcfile = False
+        
+        if rcfile:
+            do_rcfile = True
+            if rcfile and os.path.exists(os.path.expanduser(rcfile)):
+                files.append(rcfile)
 
         return dict(
             stdin=stdin,
             command=command,
-            do_rcfile=False,
+            do_rcfile=do_rcfile,
             envvar=None,
-            files=[],
+            files=files,
             bind_files=[],
             source_bind_files=(not norc)
         )
@@ -76,6 +82,9 @@ class PowerShell(CMD):
                 ex.unsetenv(startup_sequence["envvar"])
             if bind_rez:
                 ex.interpreter._bind_interactive_rez()
+            if startup_sequence["do_rcfile"]:
+                for f in startup_sequence["files"]:
+                    ex.source(f)                
             if print_msg and not quiet:
                 ex.info('You are now in a rez-configured environment.')
 

--- a/src/rezplugins/shell/powershell.py
+++ b/src/rezplugins/shell/powershell.py
@@ -50,7 +50,7 @@ class PowerShell(CMD):
         files = []
         do_rcfile = False
         
-        if rcfile:
+        if rcfile and (command is None):
             do_rcfile = True
             if rcfile and os.path.exists(os.path.expanduser(rcfile)):
                 files.append(rcfile)


### PR DESCRIPTION
Hello,

We are using the --rcflag on our linux systems to mannage the defaults alias and customize the prompt with more information.

To have the same behavior on windows, I changed the code to inject the value of --rcfile inside the `rez-shell.ps1`
It is injected just before the info message ```You are now in a rez-configured environment```
So just after the default ```prompt``` override so that the specified rcfile can override the prompt.

This has only been tested on windows